### PR TITLE
check db integrity on startup

### DIFF
--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -138,7 +138,7 @@ class ArangoSampleStorage:
                     # the sample document was never saved for this version doc
                     self._delete_version_and_node_docs(uver, ts, self._deletion_delay)
                 else:
-                    version = self._get_int_version_from_sample_doc(sampledoc, uver)
+                    version = self._get_int_version_from_sample_doc(sampledoc, str(uver))
                     if version:
                         self._update_version_and_node_docs_with_find(id_, uver, version)
                     else:
@@ -147,9 +147,9 @@ class ArangoSampleStorage:
             # this is a real pain to test.
             raise _SampleStorageError('Connection to database failed: ' + str(e)) from e
 
-    def _get_int_version_from_sample_doc(self, sampledoc, uuidver):
+    def _get_int_version_from_sample_doc(self, sampledoc, uuidverstr):
         for i, v in enumerate(sampledoc[_FLD_VERSIONS]):
-            if v == uuidver:
+            if v == uuidverstr:
                 return i + 1
         return None
 

--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -5,10 +5,10 @@ An ArangoDB based storage system for the Sample service.
 # may need to extract an interface at some point, YAGNI for now.
 
 import arango as _arango
-import datetime as _datetime
+import datetime
 import hashlib as _hashlib
 import uuid as _uuid
-from typing import List as _List, cast as _cast, Optional as _Optional
+from typing import List as _List, cast as _cast, Optional as _Optional, Callable
 
 from uuid import UUID
 from arango.database import StandardDatabase
@@ -74,7 +74,9 @@ class ArangoSampleStorage:
             version_collection: str,
             version_edge_collection: str,
             node_collection: str,
-            node_edge_collection: str,):
+            node_edge_collection: str,
+            now: Callable[[], datetime.datetime] = lambda: datetime.datetime.now(
+                tz=datetime.timezone.utc)):
         '''
         Create the wrapper.
         :param db: the ArangoDB database in which data will be stored.
@@ -87,11 +89,14 @@ class ArangoSampleStorage:
             will be stored.
         :param version_edges_collection: the name of the collection in which edges from sample
             nodes to sample nodes (or versions in the case of root nodes) will be stored.
+        :param now: A callable that returns the current time. Primarily used for testing.
         '''
         # Maybe make a configuration class...?
         # TODO take workspace shadow object collection & check indexes exist, don't create
         _not_falsy(db, 'db')
+        _not_falsy(now, 'now')
         self._db = db
+        self._now = now
         self._col_sample = _init_collection(
             db, sample_collection, 'sample collection', 'sample_collection')
         self._col_version = _init_collection(
@@ -104,6 +109,8 @@ class ArangoSampleStorage:
         self._col_node_edge = _init_collection(
             db, node_edge_collection, 'node edge collection', 'node_edge_collection', edge=True)
         self._ensure_indexes()
+        self._deletion_delay = datetime.timedelta(hours=1)  # make configurable?
+        self._check_db_updated()
 
     def _ensure_indexes(self):
         try:
@@ -111,6 +118,53 @@ class ArangoSampleStorage:
         except _arango.exceptions.IndexCreateError as e:
             # this is a real pain to test.
             raise _SampleStorageError('Connection to database failed: ' + str(e)) from e
+
+    def _check_db_updated(self):
+        self._check_col_updated(self._col_version)
+        self._check_col_updated(self._col_nodes)
+
+    def _check_col_updated(self, col):
+        # this should rarely find unupdated documents so don't worry too much about performance
+        try:
+            # TODO index ver field for nodes and versions
+            # TODO INdex uuid ver field for versions, ver edge, node edge
+            cur = col.find({_FLD_VER: _VAL_NO_VER})
+            for doc in cur:
+                id_ = UUID(doc[_FLD_ID])
+                uver = UUID(doc[_FLD_UUID_VER])
+                ts = self._timestamp_to_datetime(doc[_FLD_SAVE_TIME])
+                sampledoc = self._get_sample_doc(id_, exception=False)
+                if not sampledoc:
+                    # the sample document was never saved for this version doc
+                    self._delete_version_and_node_docs(uver, ts, self._deletion_delay)
+                else:
+                    version = self._get_int_version_from_sample_doc(sampledoc, uver)
+                    if version:
+                        self._update_version_and_node_docs_with_find(id_, uver, version)
+                    else:
+                        self._delete_version_and_node_docs(uver, ts, self._deletion_delay)
+        except _arango.exceptions.DocumentGetError as e:
+            # this is a real pain to test.
+            raise _SampleStorageError('Connection to database failed: ' + str(e)) from e
+
+    def _get_int_version_from_sample_doc(self, sampledoc, uuidver):
+        for i, v in enumerate(sampledoc[_FLD_VERSIONS]):
+            if v == uuidver:
+                return i + 1
+        return None
+
+    def _delete_version_and_node_docs(self, uuidver, savedate, deletion_delay):
+        if self._now() - savedate > self._deletion_delay:
+            try:
+                # TODO logging
+                # delete edge docs first to ensure we don't orphan them
+                self._col_ver_edge.delete_match({_FLD_UUID_VER: str(uuidver)})
+                self._col_version.delete_match({_FLD_UUID_VER: str(uuidver)})
+                self._col_node_edge.delete_match({_FLD_UUID_VER: str(uuidver)})
+                self._col_nodes.delete_match({_FLD_UUID_VER: str(uuidver)})
+            except _arango.exceptions.DocumentDeleteError as e:
+                # this is a real pain to test.
+                raise _SampleStorageError('Connection to database failed: ' + str(e)) from e
 
     def save_sample(self, user_name: str, sample: SampleWithID) -> bool:
         '''
@@ -210,6 +264,7 @@ class ArangoSampleStorage:
                 parentid = self._get_node_id(sample.id, versionid, _cast(str, n.parent))
                 to = f'{self._col_nodes.name}/{parentid}'
             nedoc = {_FLD_ARANGO_KEY: key,
+                     _FLD_UUID_VER: str(versionid),
                      _FLD_ARANGO_FROM: f'{self._col_nodes.name}/{key}',
                      _FLD_ARANGO_TO: to
                      }
@@ -234,6 +289,7 @@ class ArangoSampleStorage:
         # TODO this actually isn't tested by anything since we're not doing traversals yet, but
         # it will be
         veredgedoc = {_FLD_ARANGO_KEY: verdocid,
+                      _FLD_UUID_VER: str(versionid),
                       _FLD_ARANGO_FROM: f'{self._col_version.name}/{verdocid}',
                       _FLD_ARANGO_TO: f'{self._col_sample.name}/{sample.id}',
                       }
@@ -362,10 +418,12 @@ class ArangoSampleStorage:
             self._update_version_and_node_docs_with_find(id_, verdoc[_FLD_UUID_VER], version)
 
         nodes = self._get_nodes(id_, UUID(verdoc[_FLD_NODE_UUID_VER]), version)
-        dt = _datetime.datetime.fromtimestamp(
-            verdoc[_FLD_SAVE_TIME], tz=_datetime.timezone.utc)
+        dt = self._timestamp_to_datetime(verdoc[_FLD_SAVE_TIME])
 
         return SampleWithID(UUID(doc[_FLD_ID]), nodes, dt, verdoc[_FLD_NAME], version)
+
+    def _timestamp_to_datetime(self, ts: float) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
 
     def _get_version_id(self, id_: UUID, ver: UUID):
         return f'{id_}_{ver}'

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -93,6 +93,11 @@ def test_startup_with_unupdated_version_and_node_docs(samplestorage):
         samplestorage._col_nodes.name,
         samplestorage._col_node_edge.name)
 
+    assert samplestorage._col_version.count() == 1
+    assert samplestorage._col_ver_edge.count() == 1
+    assert samplestorage._col_nodes.count() == 4
+    assert samplestorage._col_node_edge.count() == 4
+
     for v in samplestorage._col_version.all():
         assert v['ver'] == 1
 
@@ -133,6 +138,11 @@ def test_startup_with_unupdated_node_docs(samplestorage):
         samplestorage._col_ver_edge.name,
         samplestorage._col_nodes.name,
         samplestorage._col_node_edge.name)
+
+    assert samplestorage._col_version.count() == 2
+    assert samplestorage._col_ver_edge.count() == 2
+    assert samplestorage._col_nodes.count() == 8
+    assert samplestorage._col_node_edge.count() == 8
 
     for v in samplestorage._col_version.all():
         assert v['ver'] == 2 if v['uuidver'] == uuidver2 else 1

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -66,6 +66,227 @@ def samplestorage_method(arango):
         TEST_COL_NODE_EDGE)
 
 
+def test_startup_with_unupdated_version_and_node_docs(samplestorage):
+    # this test simulates a server coming up after a dirty shutdown, where version and
+    # node doc integer versions have not been updated
+    n1 = SampleNode('root')
+    n2 = SampleNode('kid1', SubSampleType.TECHNICAL_REPLICATE, 'root')
+    n3 = SampleNode('kid2', SubSampleType.SUB_SAMPLE, 'kid1')
+    n4 = SampleNode('kid3', SubSampleType.TECHNICAL_REPLICATE, 'root')
+
+    id_ = uuid.UUID('1234567890abcdef1234567890abcdef')
+
+    assert samplestorage.save_sample(
+        'auser', SampleWithID(id_, [n1, n2, n3, n4], dt(1), 'foo')) is True
+
+    # this is very naughty
+    # checked that these modifications actually work by viewing the db contents
+    samplestorage._col_version.update_match({}, {'ver': -1})
+    samplestorage._col_nodes.update_match({'name': 'kid2'}, {'ver': -1})
+
+    # this is also very naughty
+    ArangoSampleStorage(
+        samplestorage._db,
+        samplestorage._col_sample.name,
+        samplestorage._col_version.name,
+        samplestorage._col_ver_edge.name,
+        samplestorage._col_nodes.name,
+        samplestorage._col_node_edge.name)
+
+    for v in samplestorage._col_version.all():
+        assert v['ver'] == 1
+
+    for v in samplestorage._col_nodes.all():
+        assert v['ver'] == 1
+
+
+def test_startup_with_unupdated_node_docs(samplestorage):
+    # this test simulates a server coming up after a dirty shutdown, where
+    # node doc integer versions have not been updated
+    # version doc cannot be modified such that ver = -1 or the version check will also correct the
+    # node docs, negating the point of this test
+    n1 = SampleNode('root')
+    n2 = SampleNode('kid1', SubSampleType.TECHNICAL_REPLICATE, 'root')
+    n3 = SampleNode('kid2', SubSampleType.SUB_SAMPLE, 'kid1')
+    n4 = SampleNode('kid3', SubSampleType.TECHNICAL_REPLICATE, 'root')
+
+    id_ = uuid.UUID('1234567890abcdef1234567890abcdef')
+
+    assert samplestorage.save_sample(
+        'auser', SampleWithID(id_, [n1, n2, n3, n4], dt(1), 'foo')) is True
+
+    assert samplestorage.save_sample_version(
+        SampleWithID(id_, [n1, n2, n3, n4], dt(1), 'bar')) == 2
+
+    # this is very naughty
+    sample = samplestorage._col_sample.find({}).next()
+    uuidver2 = sample['vers'][1]
+
+    # checked that these modifications actually work by viewing the db contents
+    samplestorage._col_nodes.update_match({'uuidver': uuidver2, 'name': 'kid2'}, {'ver': -1})
+
+    # this is also very naughty
+    ArangoSampleStorage(
+        samplestorage._db,
+        samplestorage._col_sample.name,
+        samplestorage._col_version.name,
+        samplestorage._col_ver_edge.name,
+        samplestorage._col_nodes.name,
+        samplestorage._col_node_edge.name)
+
+    for v in samplestorage._col_version.all():
+        assert v['ver'] == 2 if v['uuidver'] == uuidver2 else 1
+
+    for v in samplestorage._col_nodes.all():
+        assert v['ver'] == 2 if v['uuidver'] == uuidver2 else 1
+
+
+def test_startup_with_no_sample_doc(samplestorage):
+    # this test simulates a server coming up after a dirty shutdown, where version and
+    # node docs were saved but the sample document was not while saving the first version of
+    # a sample
+    n1 = SampleNode('root')
+    n2 = SampleNode('kid1', SubSampleType.TECHNICAL_REPLICATE, 'root')
+    n3 = SampleNode('kid2', SubSampleType.SUB_SAMPLE, 'kid1')
+    n4 = SampleNode('kid3', SubSampleType.TECHNICAL_REPLICATE, 'root')
+
+    id1 = uuid.UUID('1234567890abcdef1234567890abcdef')
+    id2 = uuid.UUID('1234567890abcdef1234567890abcdea')
+
+    assert samplestorage.save_sample(
+        'auser', SampleWithID(id1, [n1, n2, n3, n4], dt(1), 'foo')) is True
+
+    assert samplestorage.save_sample(
+        'auser', SampleWithID(id2, [n1, n2, n3, n4], dt(1000), 'foo')) is True
+
+    # this is very naughty
+    assert samplestorage._col_version.count() == 2
+    assert samplestorage._col_ver_edge.count() == 2
+    assert samplestorage._col_nodes.count() == 8
+    assert samplestorage._col_node_edge.count() == 8
+
+    samplestorage._col_sample.delete({'_key': str(id2)})
+    # if the sample document hasn't been saved, then none of the integer versions for the
+    # sample can have been updated to 1
+    samplestorage._col_version.update_match({'id': str(id2)}, {'ver': -1})
+    samplestorage._col_nodes.update_match({'id': str(id2)}, {'ver': -1})
+
+    # first test that bringing up the server before the 1hr deletion time limit doesn't change the
+    # db:
+    # this is also very naughty
+    ArangoSampleStorage(
+        samplestorage._db,
+        samplestorage._col_sample.name,
+        samplestorage._col_version.name,
+        samplestorage._col_ver_edge.name,
+        samplestorage._col_nodes.name,
+        samplestorage._col_node_edge.name,
+        now=lambda: datetime.datetime.fromtimestamp(4600, tz=datetime.timezone.utc))
+
+    assert samplestorage._col_version.count() == 2
+    assert samplestorage._col_ver_edge.count() == 2
+    assert samplestorage._col_nodes.count() == 8
+    assert samplestorage._col_node_edge.count() == 8
+
+    # now test that bringing up the server after the limit deletes the docs:
+    ArangoSampleStorage(
+        samplestorage._db,
+        samplestorage._col_sample.name,
+        samplestorage._col_version.name,
+        samplestorage._col_ver_edge.name,
+        samplestorage._col_nodes.name,
+        samplestorage._col_node_edge.name,
+        now=lambda: datetime.datetime.fromtimestamp(4601, tz=datetime.timezone.utc))
+
+    assert samplestorage._col_sample.count() == 1
+    assert samplestorage._col_version.count() == 1
+    assert samplestorage._col_ver_edge.count() == 1
+    assert samplestorage._col_nodes.count() == 4
+    assert samplestorage._col_node_edge.count() == 4
+
+    sample = samplestorage._col_sample.find({}).next()
+    assert sample['id'] == str(id1)
+    uuidver = sample['vers'][0]
+
+    assert len(list(samplestorage._col_version.find({'uuidver': uuidver}))) == 1
+    assert len(list(samplestorage._col_ver_edge.find({'uuidver': uuidver}))) == 1
+    assert len(list(samplestorage._col_nodes.find({'uuidver': uuidver}))) == 4
+    assert len(list(samplestorage._col_node_edge.find({'uuidver': uuidver}))) == 4
+
+
+def test_startup_with_no_version_in_sample_doc(samplestorage):
+    # this test simulates a server coming up after a dirty shutdown, where version and
+    # node docs were saved but the sample document was not updated while saving the second
+    # version of # a sample
+    n1 = SampleNode('root')
+    n2 = SampleNode('kid1', SubSampleType.TECHNICAL_REPLICATE, 'root')
+    n3 = SampleNode('kid2', SubSampleType.SUB_SAMPLE, 'kid1')
+    n4 = SampleNode('kid3', SubSampleType.TECHNICAL_REPLICATE, 'root')
+
+    id1 = uuid.UUID('1234567890abcdef1234567890abcdef')
+
+    assert samplestorage.save_sample(
+        'auser', SampleWithID(id1, [n1, n2, n3, n4], dt(1), 'foo')) is True
+
+    assert samplestorage.save_sample_version(
+        SampleWithID(id1, [n1, n2, n3, n4], dt(2000), 'foo')) == 2
+
+    # this is very naughty
+    assert samplestorage._col_sample.count() == 1
+    assert samplestorage._col_version.count() == 2
+    assert samplestorage._col_ver_edge.count() == 2
+    assert samplestorage._col_nodes.count() == 8
+    assert samplestorage._col_node_edge.count() == 8
+
+    sample = samplestorage._col_sample.find({}).next()
+    samplestorage._col_sample.update_match({}, {'vers': sample['vers'][:1]})
+    uuidver2 = sample['vers'][1]
+
+    # if the sample document hasn't been updated, then none of the integer versions for the
+    # sample can have been updated to 1
+    samplestorage._col_version.update_match({'uuidver': uuidver2}, {'ver': -1})
+    samplestorage._col_nodes.update_match({'uuidver': uuidver2}, {'ver': -1})
+
+    # first test that bringing up the server before the 1hr deletion time limit doesn't change the
+    # db:
+    # this is also very naughty
+    ArangoSampleStorage(
+        samplestorage._db,
+        samplestorage._col_sample.name,
+        samplestorage._col_version.name,
+        samplestorage._col_ver_edge.name,
+        samplestorage._col_nodes.name,
+        samplestorage._col_node_edge.name,
+        now=lambda: datetime.datetime.fromtimestamp(5600, tz=datetime.timezone.utc))
+
+    assert samplestorage._col_version.count() == 2
+    assert samplestorage._col_ver_edge.count() == 2
+    assert samplestorage._col_nodes.count() == 8
+    assert samplestorage._col_node_edge.count() == 8
+
+    # now test that bringing up the server after the limit deletes the docs:
+    ArangoSampleStorage(
+        samplestorage._db,
+        samplestorage._col_sample.name,
+        samplestorage._col_version.name,
+        samplestorage._col_ver_edge.name,
+        samplestorage._col_nodes.name,
+        samplestorage._col_node_edge.name,
+        now=lambda: datetime.datetime.fromtimestamp(5601, tz=datetime.timezone.utc))
+
+    assert samplestorage._col_version.count() == 1
+    assert samplestorage._col_ver_edge.count() == 1
+    assert samplestorage._col_nodes.count() == 4
+    assert samplestorage._col_node_edge.count() == 4
+
+    uuidver1 = sample['vers'][0]
+
+    assert len(list(samplestorage._col_version.find({'uuidver': uuidver1}))) == 1
+    assert len(list(samplestorage._col_ver_edge.find({'uuidver': uuidver1}))) == 1
+    assert len(list(samplestorage._col_nodes.find({'uuidver': uuidver1}))) == 4
+    assert len(list(samplestorage._col_node_edge.find({'uuidver': uuidver1}))) == 4
+
+
 def test_fail_startup_bad_args(arango):
     samplestorage_method(arango)
     db = arango.client.db(TEST_DB_NAME, TEST_USER, TEST_PWD)
@@ -75,13 +296,19 @@ def test_fail_startup_bad_args(arango):
     ve = TEST_COL_VER_EDGE
     n = TEST_COL_NODES
     ne = TEST_COL_NODE_EDGE
-    _fail_startup(None, s, v, ve, n, ne,
+
+    def nw():
+        datetime.datetime.fromtimestamp(1, tz=datetime.timezone.utc)
+
+    _fail_startup(None, s, v, ve, n, ne, nw,
                   ValueError('db cannot be a value that evaluates to false'))
-    _fail_startup(db, '', v, ve, n, ne, MissingParameterError('sample_collection'))
-    _fail_startup(db, s, '', ve, n, ne, MissingParameterError('version_collection'))
-    _fail_startup(db, s, v, '', n, ne, MissingParameterError('version_edge_collection'))
-    _fail_startup(db, s, v, ve, '', ne, MissingParameterError('node_collection'))
-    _fail_startup(db, s, v, ve, n, '', MissingParameterError('node_edge_collection'))
+    _fail_startup(db, '', v, ve, n, ne, nw, MissingParameterError('sample_collection'))
+    _fail_startup(db, s, '', ve, n, ne, nw, MissingParameterError('version_collection'))
+    _fail_startup(db, s, v, '', n, ne, nw, MissingParameterError('version_edge_collection'))
+    _fail_startup(db, s, v, ve, '', ne, nw, MissingParameterError('node_collection'))
+    _fail_startup(db, s, v, ve, n, '', nw, MissingParameterError('node_edge_collection'))
+    _fail_startup(db, s, v, ve, n, ne, None,
+                  ValueError('now cannot be a value that evaluates to false'))
 
 
 def test_fail_startup_incorrect_collection_type(arango):
@@ -94,21 +321,25 @@ def test_fail_startup_incorrect_collection_type(arango):
     ve = TEST_COL_VER_EDGE
     n = TEST_COL_NODES
     ne = TEST_COL_NODE_EDGE
-    _fail_startup(db, 'sampleedge', v, ve, n, ne, StorageInitException(
+
+    def nw():
+        datetime.datetime.fromtimestamp(1, tz=datetime.timezone.utc)
+
+    _fail_startup(db, 'sampleedge', v, ve, n, ne, nw, StorageInitException(
         'sample collection sampleedge is not a vertex collection'))
-    _fail_startup(db, s, ve, ve, n, ne, StorageInitException(
+    _fail_startup(db, s, ve, ve, n, ne, nw, StorageInitException(
                   'version collection ver_to_sample is not a vertex collection'))
-    _fail_startup(db, s, v, v, n, ne, StorageInitException(
+    _fail_startup(db, s, v, v, n, ne, nw, StorageInitException(
                   'version edge collection versions is not an edge collection'))
-    _fail_startup(db, s, v, ve, ne, ne, StorageInitException(
+    _fail_startup(db, s, v, ve, ne, ne, nw, StorageInitException(
                   'node collection node_edges is not a vertex collection'))
-    _fail_startup(db, s, v, ve, n, n, StorageInitException(
+    _fail_startup(db, s, v, ve, n, n, nw, StorageInitException(
                   'node edge collection nodes is not an edge collection'))
 
 
-def _fail_startup(db, colsample, colver, colveredge, colnode, colnodeedge, expected):
+def _fail_startup(db, colsample, colver, colveredge, colnode, colnodeedge, now, expected):
     with raises(Exception) as got:
-        ArangoSampleStorage(db, colsample, colver, colveredge, colnode, colnodeedge)
+        ArangoSampleStorage(db, colsample, colver, colveredge, colnode, colnodeedge, now=now)
     assert_exception_correct(got.value, expected)
 
 


### PR DESCRIPTION
Looks for version and node documents with an integer version of  -1, indicating
that the save failed before updating can occur.

If the corresponding sample doc doesn't exist or doesn't contain the uuid
version for the version/node doc, then the version is deleted from the
system assuming at least an hour has passed since they were saved.

Otherwise, the version and node docs are updated with the appropriate integer
version.