### PR TITLE
Explicitly turn off db correcting code in tests

### DIFF
--- a/lib/SampleService/core/storage/arango_sample_storage.py
+++ b/lib/SampleService/core/storage/arango_sample_storage.py
@@ -255,6 +255,7 @@ class ArangoSampleStorage:
 
     def _delete_version_and_node_docs(self, uuidver, savedate, deletion_delay):
         if self._now() - savedate > self._deletion_delay:
+            print('deleting docs', self._now(), savedate, self._deletion_delay)
             try:
                 # TODO logging
                 # delete edge docs first to ensure we don't orphan them
@@ -312,7 +313,6 @@ class ArangoSampleStorage:
     # this method is separated so we can test the race condition case where a sample with the
     # same ID is saved after the check above.
     def _save_sample_pt2(self, user_name: str, sample: SampleWithID) -> bool:
-        # TODO explain why save works as it does, including versioning
 
         versionid = _uuid.uuid4()
 

--- a/test/core/storage/arango_sample_storage_test.py
+++ b/test/core/storage/arango_sample_storage_test.py
@@ -565,6 +565,12 @@ def test_consistency_checker_run(samplestorage):
 
     assert samplestorage._col_nodes.find({'uuidver': uuidver2, 'name': 'kid2'}).next()['ver'] == 2
 
+    # leaving the checker running can occasionally interfere with other tests, deleting documents
+    # that are in the middle of the save process. Stop the checker and wait until the job must've
+    # run.
+    samplestorage.stop_consistency_checker()
+    time.sleep(1)
+
 
 def dt(timestamp):
     return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)


### PR DESCRIPTION
... rather than relying on garbage collector.

Think it was interfering with other tests by deleting docs during the save
process.