### PR TITLE
Fix bug in py server & add failing save test

### DIFF
--- a/lib/SampleService/SampleServiceServer.py
+++ b/lib/SampleService/SampleServiceServer.py
@@ -117,7 +117,12 @@ class JSONRPCServiceCustom(JSONRPCService):
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
             if len(e.args) == 1:
-                newerr.data = repr(e.args[0])
+                # THIS WAS CHANGED INTENTIONALLY - if you recompile please restore.
+                # repr adds single quotes around string arguments which is not what we want.
+                if type(e.args[0]) == str:
+                    newerr.data = str(e.args[0])
+                else:
+                    newerr.data = repr(e.args[0])
             else:
                 newerr.data = repr(e.args)
             raise newerr


### PR DESCRIPTION
The py server reprs the contents of the exception's args tuple, which in
the case of ('some string',) will result in an exception message of
"'some string'".
Bug was introduced here: https://github.com/kbase/kb_sdk/pull/323