### PR TITLE
Require acls key to be present and a dict in replace acls method

### DIFF
--- a/lib/SampleService/core/api_arguments.py
+++ b/lib/SampleService/core/api_arguments.py
@@ -207,16 +207,12 @@ def acls_from_dict(d: Dict[str, Any]) -> SampleACLOwnerless:
 
     :param params: The dict containing the ACLS.
     :returns: the ACLs.
-    :raises MissingParameterError: if any of the required arguments are missing.
     :raises IllegalParameterError: if any of the arguments are illegal.
     '''
     _not_falsy(d, 'd')
-    if not d.get('acls'):
-        # TODO should fail here if None or not a dict
-        return SampleACLOwnerless()
+    if d.get('acls') is None or type(d['acls']) != dict:
+        raise _IllegalParameterError('ACLs must be supplied in the acls key and must be a mapping')
     acls = d['acls']
-    if not type(acls) == dict:
-        raise _IllegalParameterError('Input ACLs must be a mapping')
     _check_acl(acls, 'admin')
     _check_acl(acls, 'write')
     _check_acl(acls, 'read')

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -699,7 +699,8 @@ def test_replace_acls_fail_bad_acls(sample_port):
     })
     assert ret.status_code == 500
     assert ret.json()['error']['message'] == (
-        'Sample service error code 30001 Illegal input parameter: Input ACLs must be a mapping')
+        'Sample service error code 30001 Illegal input parameter: ' +
+        'ACLs must be supplied in the acls key and must be a mapping')
 
 
 def test_replace_acls_fail_permissions(sample_port):

--- a/test/core/api_arguments_test.py
+++ b/test/core/api_arguments_test.py
@@ -385,7 +385,9 @@ def test_acls_from_dict():
 def test_acls_from_dict_fail_bad_args():
     _acls_from_dict_fail(None, ValueError('d cannot be a value that evaluates to false'))
     _acls_from_dict_fail({}, ValueError('d cannot be a value that evaluates to false'))
-    _acls_from_dict_fail({'acls': 'foo'}, IllegalParameterError('Input ACLs must be a mapping'))
+    m = 'ACLs must be supplied in the acls key and must be a mapping'
+    _acls_from_dict_fail({'acls': None}, IllegalParameterError(m))
+    _acls_from_dict_fail({'acls': 'foo'}, IllegalParameterError(m))
     _acls_from_dict_fail_acl_check('read')
     _acls_from_dict_fail_acl_check('write')
     _acls_from_dict_fail_acl_check('admin')


### PR DESCRIPTION
Too easy to accidentally blow away the current acls otherwise