### PR TITLE
Fix race condition on setting acls

### DIFF
--- a/lib/SampleService/core/acls.py
+++ b/lib/SampleService/core/acls.py
@@ -4,7 +4,7 @@ Classes and methods for working with sample ACLs.
 
 from enum import IntEnum
 
-from typing import List
+from typing import Sequence
 from SampleService.core.arg_checkers import not_falsy as _not_falsy
 from SampleService.core.arg_checkers import not_falsy_in_iterable as _not_falsy_in_iterable
 
@@ -32,9 +32,9 @@ class SampleACLOwnerless:
 
     def __init__(
             self,
-            admin: List[str] = None,
-            write: List[str] = None,
-            read: List[str] = None):
+            admin: Sequence[str] = None,
+            write: Sequence[str] = None,
+            read: Sequence[str] = None):
         '''
         Create the ACLs.
 
@@ -59,7 +59,7 @@ class SampleACLOwnerless:
 
 class SampleACL(SampleACLOwnerless):
     '''
-    An Access Control List for a sample, consisting of user names for various privileges.
+    An Access Control Sequence for a sample, consisting of user names for various privileges.
 
     :ivar owner: the owner username.
     :ivar admin: the list of admin usernames.
@@ -70,9 +70,9 @@ class SampleACL(SampleACLOwnerless):
     def __init__(
             self,
             owner: str,
-            admin: List[str] = None,
-            write: List[str] = None,
-            read: List[str] = None):
+            admin: Sequence[str] = None,
+            write: Sequence[str] = None,
+            read: Sequence[str] = None):
         '''
         Create the ACLs.
 

--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -163,7 +163,9 @@ class Samples:
         _not_falsy(new_acls, 'new_acls')
         acls = self._storage.get_sample_acls(_not_falsy(id_, 'id_'))
         self._check_perms(id_, user, _SampleAccessType.ADMIN, acls)
-        # TODO check users are valid
+        # TODO ACL check users are valid
+        # TODO ACL handle owner changed exception
+        new_acls = SampleACL(acls.owner, new_acls.admin, new_acls.write, new_acls.read)
         self._storage.replace_sample_acls(id_, new_acls)
 
     # TODO change owner. Probably needs a request/accept flow.

--- a/lib/SampleService/core/storage/errors.py
+++ b/lib/SampleService/core/storage/errors.py
@@ -13,3 +13,11 @@ class StorageInitException(SampleStorageError):
     """
     Denotes an error during initialization of the storage system.
     """
+
+
+class OwnerChangedException(SampleStorageError):
+    """
+    Denotes that the owner designated by a save operation is not the same as the owner in the
+    database - e.g. the owner has changed since the ACLs were last pulled from the database.
+    This error generally denotes a race condition has occurred.
+    """

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -573,8 +573,8 @@ def test_get_and_replace_acls(sample_port):
         'read': [USER2]
     })
 
-    # TODO check users are only in one acl
-    # TODO check owner is not in acl, and when saving has not changed since fetch
+    # TODO ACL check users are only in one acl
+    # TODO ACL check owner is not in acl
 
 
 def _replace_acls(url, id_, token, acls):


### PR DESCRIPTION
If the owner has changed between  fetching acls from the DB and saving back
updated ACLs, the owner might also be listed in admin/write/read ACLs.
This change ensures that the owner hasn't changed since the ACLs were
retrieved.

Next is to check that the ACLs are consistent  - e.g. no user appears more than
once in the ACLs.