### PR TITLE
Trivial change because dynamic services are stupid

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ To use this code in another SDK module, call `kb-sdk install SampleService` in t
 
 # Help
 
-You may find the answers to your questions in our [FAQ](https://kbase.github.io/kb_sdk_docs/references/questions_and_answers.html) or [Troubleshooting Guide](https://kbase.github.io/kb_sdk_docs/references/troubleshooting.html).
+You may find the answers to your questions in our [FAQ](https://kbase.github.io/kb_sdk_docs/references/questions_and_answers.html) or [Troubleshooting Guide](https://kbase.github.io/kb_sdk_docs/references/troubleshooting.html). 


### PR DESCRIPTION
The dynamic service manager will just start the old container if there's no new
commit, even if the catalog parameters for the module have changed. This means
the deploy.cfg file is not updated with the new parameters and so the
service will still fail to start.