### PR TITLE
Don't throw an error in validator on bad meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,10 @@ argument. E.g. in the case of the `temperature` key, the argument to the functio
  }
 ```
 
-If the metadata is incorrect, the validator should [TODO currently requires throwing an exception,
-which means the validator has to import the server code. Change to returning an error string.]
-
-If the validator cannot validate the metadata due to some uncontrollable error (e.g. it can't
-connect to an external server after a reasonable timeout), it should throw an exception.
+If the metadata is incorrect, the validator should return an error message as a string. Otherwise
+it should return `None` unless the validator cannot validate the metadata due to some
+uncontrollable error (e.g. it can't connect to an external server after a reasonable timeout),
+in which case it should throw an exception.
 
 [TODO redo validator configuration to pull a yaml file from a url rather than using catalog
  params and document here]
@@ -142,15 +141,15 @@ connect to an external server after a reasonable timeout), it should throw an ex
  A very simple example might be:
 
  ```python
- def enum_builder(params: Dict[str, str]):
+ def enum_builder(params: Dict[str, str]
+        ) -> Callable[[Dict[str, Union[float, int, bool, str]]], str]:
     # should handle errors better here
     enums = {e.strip() for e in d['enums'].split(',')}
     key = d['key']
 
-    def validate_enum(value: Dict[str, Union[float, int, bool, str]]):
-        # should check for missing key
-        if value[key] not in enums:
-            return f'Illegal value: value[key]'
+    def validate_enum(value: Dict[str, Union[float, int, bool, str]]) -> str:
+        if value.get(key) not in enums:
+            return f'Illegal value for key {key}: {value.get(key)}'
         return None
 
     return validate_enum

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
     as the experimental techniques don't allow it.
 
 # Functionality
-* change validator error to returned string
 * Config in separate repo
   * Means validator config is public
 * Admin flags on ops

--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -7,7 +7,7 @@ Configuration parsing and creation for the sample service.
 
 import importlib
 from collections import defaultdict as _defaultdict
-from typing import Dict, Callable, Optional as _Optional, cast as _cast
+from typing import Dict, Callable, Optional, cast as _cast
 from typing import DefaultDict as _DefaultDict
 import arango as _arango
 
@@ -84,11 +84,13 @@ def build_samples(config: Dict[str, str]) -> Samples:
     return Samples(storage, user_lookup, metaval)
 
 
-def _check_string_req(s: _Optional[str], name: str) -> str:
+def _check_string_req(s: Optional[str], name: str) -> str:
     return _cast(str, _check_string(s, name))
 
 
-def get_validators(cfg: Dict[str, str]) -> Dict[str, Callable[[Dict[str, PrimitiveType]], None]]:
+def get_validators(
+        cfg: Dict[str, str]
+        ) -> Dict[str, Callable[[Dict[str, PrimitiveType]], Optional[str]]]:
     '''
     Given an SDK server generated config mapping, initialize any metadata validators present
     in the configuration.

--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -34,7 +34,8 @@ class Samples:
             self,
             storage: ArangoSampleStorage,
             user_lookup: KBaseUserLookup,  # make an interface? YAGNI
-            metadata_validators: Dict[str, Callable[[Dict[str, PrimitiveType]], None]] = None,
+            metadata_validators: Dict[
+                str, Callable[[Dict[str, PrimitiveType]], Optional[str]]] = None,
             now: Callable[[], datetime.datetime] = lambda: datetime.datetime.now(
                 tz=datetime.timezone.utc),
             uuid_gen: Callable[[], UUID] = lambda: _uuid.uuid4()):
@@ -104,11 +105,9 @@ class Samples:
                 if k not in self._metaval:
                     raise _MetadataValidationError(
                         f'No validator available for metadata key {k} for node at index {i}')
-                try:
-                    self._metaval[k](n.controlled_metadata[k])
-                except _MetadataValidationError as e:
-                    raise _MetadataValidationError(
-                        f'Node at index {i}, key {k}: ' + _cast(str, e.message)) from e
+                ret = self._metaval[k](n.controlled_metadata[k])
+                if ret:
+                    raise _MetadataValidationError(f'Node at index {i}, key {k}: ' + ret)
 
     def _check_perms(
             self,

--- a/lib/SampleService/core/validators/builtin.py
+++ b/lib/SampleService/core/validators/builtin.py
@@ -15,7 +15,6 @@ If an error is not thrown, the validation succeeds.
 
 from typing import Dict, cast as _cast
 from SampleService.core.core_types import PrimitiveType
-from SampleService.core.errors import MetadataValidationError
 
 
 def noop(d: Dict[str, str]):
@@ -48,11 +47,9 @@ def string_length(d: Dict[str, str]):
     def strlen(d1: Dict[str, PrimitiveType]):
         for k, v in d1.items():
             if len(k) > maxlen:
-                raise MetadataValidationError(
-                    f'Metadata contains key longer than max length of {maxlen}')
+                return f'Metadata contains key longer than max length of {maxlen}'
             if type(v) == str:
                 if len(_cast(str, v)) > maxlen:
-                    raise MetadataValidationError(
-                        f'Metadata value at key {k} is longer than max length of {maxlen}')
+                    return f'Metadata value at key {k} is longer than max length of {maxlen}'
 
     return strlen

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -20,9 +20,10 @@ def test_config_get_validators():
            'metaval-key3-param-foo': 'bat',
            }
     vals = get_validators(cfg)
-    assert vals['key1']({'a': 'b'}) == (1, {}, {'a': 'b'})
-    assert vals['key2']({'a': 'd'}) == (2, {'foo': 'bar', 'max_len': '7'}, {'a': 'd'})
-    assert vals['key3']({'a': 'c'}) == (1, {'foo': 'bat'}, {'a': 'c'})
+    # validators always fail
+    assert vals['key1']({'a': 'b'}) == "1, {}, {'a': 'b'}"
+    assert vals['key2']({'a': 'd'}) == "2, {'foo': 'bar', 'max_len': '7'}, {'a': 'd'}"
+    assert vals['key3']({'a': 'c'}) == "1, {'foo': 'bat'}, {'a': 'c'}"
 
 
 def test_config_get_validators_fail_bad_params():

--- a/test/core/config_test_vals.py
+++ b/test/core/config_test_vals.py
@@ -1,12 +1,16 @@
+def s(d):
+    return dict(sorted(d.items()))
+
+
 def val1(d1):
     def f(d2):
-        return (1, d1, d2)
+        return f'1, {s(d1)}, {s(d2)}'
     return f
 
 
 def val2(d1):
     def f(d2):
-        return (2, d1, d2)
+        return f'2, {s(d1)}, {s(d2)}'
     return f
 
 

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -158,9 +158,7 @@ def test_save_sample_fail_no_metadata_validator():
 def test_save_sample_fail_metadata_validator_exception():
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': lambda _: None,
-               # this is vile
-               'key2': lambda _: exec('raise MetadataValidationError("u suk lol")')}
+    metaval = {'key1': lambda _: None, 'key2': lambda _: "u suk lol"}
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 

--- a/test/core/validators/builtin_test.py
+++ b/test/core/validators/builtin_test.py
@@ -2,7 +2,6 @@ from pytest import raises
 from core.test_utils import assert_exception_correct
 
 from SampleService.core.validators import builtin
-from SampleService.core.errors import MetadataValidationError
 
 
 def test_noop():
@@ -16,7 +15,7 @@ def test_string_length():
     sl = builtin.string_length({'max_len': 2})
     assert sl({
         'fo': 'b',
-        'ba': 'f',
+        'e': 'fb',
         'a': True,
         'b': 1111111111,
         'c': 1.23456789}) is None
@@ -37,14 +36,13 @@ def _string_length_fail_construct(d, expected):
 
 
 def test_string_length_fail_bad_metadata_values():
-    _string_length_fail_validate(2, {'foo': 'ba', 'ba': 'f'}, MetadataValidationError(
-        'Metadata contains key longer than max length of 2'))
-    _string_length_fail_validate(4, {'foo': 'ba', 'ba': 'fudge'}, MetadataValidationError(
-        'Metadata value at key ba is longer than max length of 4'))
+    _string_length_fail_validate(
+        2, {'foo': 'ba', 'ba': 'f'},
+        'Metadata contains key longer than max length of 2')
+    _string_length_fail_validate(
+        4, {'foo': 'ba', 'ba': 'fudge'},
+        'Metadata value at key ba is longer than max length of 4')
 
 
 def _string_length_fail_validate(max_len, meta, expected):
-    sl = builtin.string_length({'max_len': max_len})
-    with raises(Exception) as got:
-        sl(meta)
-    assert_exception_correct(got.value, expected)
+    assert builtin.string_length({'max_len': max_len})(meta) == expected


### PR DESCRIPTION
Means validator code has to import service code, bleah. Return string instead.