### PR TITLE
Make core code take a list of validators per key

### DIFF
--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -6,7 +6,7 @@ Configuration parsing and creation for the sample service.
 # this code is mostly tested in the integration tests.
 
 import importlib
-from typing import Dict, Callable, Optional, cast as _cast
+from typing import Dict, Callable, Optional, List, cast as _cast
 import urllib as _urllib
 from urllib.error import URLError as _URLError
 import yaml as _yaml
@@ -114,7 +114,8 @@ _META_VAL_JSONSCHEMA = {
 }
 
 
-def get_validators(url: str) -> Dict[str, Callable[[Dict[str, PrimitiveType]], Optional[str]]]:
+def get_validators(url: str) -> Dict[
+        str, List[Callable[[Dict[str, PrimitiveType]], Optional[str]]]]:
     '''
     Given a url pointing to a config file, initialize any metadata validators present
     in the configuration.
@@ -138,7 +139,8 @@ def get_validators(url: str) -> Dict[str, Callable[[Dict[str, PrimitiveType]], O
         m = importlib.import_module(v['module'])
         p = v.get('parameters')
         try:
-            ret[k] = getattr(m, v['callable-builder'])(p if p else {})
+            # TODO NOW handle lists of validators
+            ret[k] = [getattr(m, v['callable-builder'])(p if p else {})]
         except Exception as e:
             raise ValueError(
                 f'Metadata validator callable build failed for key {k}: {e.args[0]}') from e

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -46,10 +46,10 @@ def test_config_get_validators(temp_dir):
     tf = _write_config(cfg, temp_dir)
     vals = get_validators('file://' + tf)
     assert len(vals) == 3
-    # validators always fail
-    assert vals['key1']({'a': 'b'}) == "1, {}, {'a': 'b'}"
-    assert vals['key2']({'a': 'd'}) == "2, {'foo': 'bar', 'max-len': 7}, {'a': 'd'}"
-    assert vals['key3']({'a': 'c'}) == "1, {'foo': 'bat'}, {'a': 'c'}"
+    # the test validators always fail
+    assert vals['key1'][0]({'a': 'b'}) == "1, {}, {'a': 'b'}"
+    assert vals['key2'][0]({'a': 'd'}) == "2, {'foo': 'bar', 'max-len': 7}, {'a': 'd'}"
+    assert vals['key3'][0]({'a': 'c'}) == "1, {'foo': 'bat'}, {'a': 'c'}"
 
     # noop entry
     cfg = {}

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -47,8 +47,11 @@ def test_save_sample():
 def _save_sample_with_name(name):
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': lambda x: exec('assert x["val"] == "foo"'),  # this is vile
-               'key2': lambda _: None}  # noop
+    metaval = {'key1': [lambda x: exec('assert x["val"] == "foo"'),  # this is vile
+                        lambda x: exec('assert "val" in x')
+                        ],
+               'key2': [lambda _: None]  # noop
+               }
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
@@ -136,7 +139,7 @@ def test_save_sample_fail_bad_args():
 def test_save_sample_fail_no_metadata_validator():
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': lambda _: None, 'key2': lambda _: None}
+    metaval = {'key1': [lambda _: None], 'key2': [lambda _: None], 'key3': []}
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
@@ -158,7 +161,7 @@ def test_save_sample_fail_no_metadata_validator():
 def test_save_sample_fail_metadata_validator_exception():
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': lambda _: None, 'key2': lambda _: "u suk lol"}
+    metaval = {'key1': [lambda _: None], 'key2': [lambda _: None, lambda _: "u suk lol"]}
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 


### PR DESCRIPTION
as opposed to a single validator. Allows for writing simpler, more general
validators and applying them in combination on keys for more complex
validations.

Still need to make the configuration file / parser handle multiple
validators.