### PR TITLE
Pass metadata keys to validators

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,7 @@ pyyaml = "==5.3"
 jsonschema = "==3.2.0"
 pint = "==0.10.1"
 python-ranges = "==0.1.3"
+confluent-kafka = "==1.3.0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4224ee5e41be4f68b3474af65d183d0d7ff21a45dac219cb418a67509a258437"
+            "sha256": "adcddc2ee757379221f3c4fb38068808b2b3fbe61f063111adfff051ddeeac56"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -53,6 +53,44 @@
             ],
             "version": "==3.0.4"
         },
+        "confluent-kafka": {
+            "hashes": [
+                "sha256:0efd716da4f03f99d45fbb0d1583c5c8bf1eabc258a883588e3cd6ee06c0facb",
+                "sha256:1bcb0d45fba5fcfa87971667490ff41ec8aae99e8c66ec61bf2c28e4dabf2737",
+                "sha256:1f52d6dd04fc81cb22e89a6b579cde83634f9c98218af6fcb794e8e924fc5de0",
+                "sha256:4025ccddbc79443a4e2342de0d770f669558eb737fca2e7851558cd45f78ef78",
+                "sha256:413cc9189ba7560bdc1010bbf3cabdcccfb794262f20aa867778e4059e789e88",
+                "sha256:4194c11fdfa47fe749eabe7f2bcd259e921a457b046df5fe82d11dd519412327",
+                "sha256:48941bff7b151ebe8fc5d958b8b039164ad9bbb4b5b66dde7d8c16ce36fa5ca5",
+                "sha256:4d85e900ee59cba6acbe2ed415f6b8b86c86cca4f1cf0782bca24588cb594f52",
+                "sha256:5252f989c364b1231eb4bd26db7a6acae1020af53069c7567f4f9627afab2612",
+                "sha256:6095b248c457518d3f83ecb981a819512241b3c3fd7f461f3c55405278ab7825",
+                "sha256:63245ea826238f7c41002c6583e44d07a3a25fbcedd320af4902bb22d17a67ec",
+                "sha256:70a2aa7056143ff30a8259d69327b38838f402fabbcc0699cfd8a7de4123825a",
+                "sha256:77f545e9b143b22d2f11609677aacf7d15855b0166a59634fb1b125ac209b7d7",
+                "sha256:81a1f91a82c65bc3d3d77dbb821b2c91e36ec482a5fc1dec8996c00c4c5bbd3b",
+                "sha256:8469a8780a8d6258d4be08dc882b1d2e8114cfb93ae3836c2841ecfc127efc03",
+                "sha256:86685d98e28bc9eade04a06b4979829f1d5c7785bced8cf335152e4dd363e4aa",
+                "sha256:86bfac9a48a7a77c1f4972272521f970c4bbd55975a5c7c7d172c21dea094f28",
+                "sha256:910cd945e9684c4d1ee8777258e6f3fa6a54e5ff8d361bba65b03275d0e57f18",
+                "sha256:9350101ca2db756cb9ca2c5ef410a0c19b200267add97a76c2ffa167ac59685a",
+                "sha256:98258fbe75c5d67f0e6103eec1763f9bb713e4258dbdac45ecf8805a975fdd5c",
+                "sha256:99d75d06e79ec7d489cd410717d5ad303dee2a632db5d39f5d20f1ec1a40a23e",
+                "sha256:a1925564bb10556686a9857ce22c222f1d6e66079d3379e23edec0bb3c19703b",
+                "sha256:a4600737ed4ceb6c799319d1d2977c46c00966274d868bcdeba66b655558ee26",
+                "sha256:b96882b342b78b082aeedb56ee3c35d137adeadc26a63188ea36ae46ae1d485c",
+                "sha256:c57c58f812a21fa8ad9f8bac88b4cd026dfe5b4f1fc9353d4fc0186c9b6d558e",
+                "sha256:c72c9223a95b6668a805b175ab39e10a1cb2074e1cfa32a7cace758c744c4238",
+                "sha256:ce45cc45b0dd29fb5a297a7f248f98dc5bde0142d48e07a19140f45906296b14",
+                "sha256:d060ffc618b5618b8e01bc1414104e4c595746f28029ac91b1f7b63d5bcb72f2",
+                "sha256:e3bcb44595824dd1c78980bb57804a18ff8de16e257e747bd2724db88acfee25",
+                "sha256:f294a3c3115c2b12a8f0dec6165e1bd427f3a4ca6066a9028e13f9a516c9a162",
+                "sha256:f7a8bb7a5e80776a2dd8d4f4edbef1ebd5fdb2f443f87e95e08f6f7c598c33e1",
+                "sha256:fcb975bc7b26611e3c5c32f3c584ed860703f0496b22c096642ebc36d8cb4f12"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -62,11 +100,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
-                "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "jsonrpcbase": {
             "hashes": [
@@ -276,11 +314,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
-                "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "mccabe": {
             "hashes": [
@@ -291,10 +329,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39",
-                "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
             ],
-            "version": "==8.1.0"
+            "version": "==8.2.0"
         },
         "mypy": {
             "hashes": [
@@ -426,11 +464,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600",
-                "sha256:c13d1943c63e599b98cf118fcb9703e4d7bde7caa9a432567bcdcae4bf512d20"
+                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
+                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
             ],
             "index": "pypi",
-            "version": "==5.3.4"
+            "version": "==5.3.5"
         },
         "pytest-cov": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -132,13 +132,12 @@ A simple example:
 ```
 
 In this case, a validator would need to be assigned to the `temperature` and `location`
-metadata keys. Validators are `python` callables that accept the value of the key as the only
-argument. E.g. in the case of the `temperature` key, the argument to the function would be:
+metadata keys. Validators are `python` callables that accept the key and the value of the key as
+callable parameters. E.g. in the case of the `temperature` key, the arguments to the function
+would be:
 
 ```
-{"measurement": 1.0,
- "units": "Kelvin"
- }
+("temperature", {"measurement": 1.0, "units": "Kelvin"})
 ```
 
 If the metadata is incorrect, the validator should return an error message as a string. Otherwise
@@ -157,11 +156,12 @@ in which case it should throw an exception.
         ) -> Callable[[Dict[str, Union[float, int, bool, str]]], Optional[str]]:
     # should handle errors better here
     enums = {e.strip() for e in d['enums'].split(',')}
-    key = d['key']
+    valuekey = d['key']
 
-    def validate_enum(value: Dict[str, Union[float, int, bool, str]]) -> Optional[str]:
-        if value.get(key) not in enums:
-            return f'Illegal value for key {key}: {value.get(key)}'
+    def validate_enum(key: str, value: Dict[str, Union[float, int, bool, str]]) -> Optional[str]:
+        # key parameter not needed in this case
+        if value.get(valuekey) not in enums:
+            return f'Illegal value for key {valuekey}: {value.get(valuekey)}'
         return None
 
     return validate_enum

--- a/TODO.md
+++ b/TODO.md
@@ -5,15 +5,12 @@
     as the experimental techniques don't allow it.
 
 # Functionality
-* Config in separate repo
-  * Means validator config is public
 * Admin flags on ops
 * List / find samples, possibly with...
 * Search integration
 * Logging
 * Metadata validation
   * prefix keys?
-  * Multiple validators per key?
 * Link data to samples
 * Workspace @sample integration
 * ACLs:
@@ -26,7 +23,7 @@
   document which limits the possible indexed queries to some extent.
   * Separating out the metadata documents means that traversals querying metadata would be
     more complicated or impossible.
-* Linking data may be complicated depending on the constrataints and features we want
+* Linking data may be complicated depending on the constraints and features we want
 
 # Testing
 * flake8 and bandit on test-sdkless (generated code is poopy)

--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -117,7 +117,7 @@ _META_VAL_JSONSCHEMA = {
 
 
 def get_validators(url: str) -> Dict[
-        str, List[Callable[[Dict[str, PrimitiveType]], Optional[str]]]]:
+        str, List[Callable[[str, Dict[str, PrimitiveType]], Optional[str]]]]:
     '''
     Given a url pointing to a config file, initialize any metadata validators present
     in the configuration.
@@ -137,7 +137,7 @@ def get_validators(url: str) -> Dict[
     _validate(instance=cfg, schema=_META_VAL_JSONSCHEMA)
 
     ret: _DefaultDict[
-        str, List[Callable[[Dict[str, PrimitiveType]], Optional[str]]]] = _defaultdict(list)
+        str, List[Callable[[str, Dict[str, PrimitiveType]], Optional[str]]]] = _defaultdict(list)
     for k, lv in cfg.items():
         for i, v in enumerate(lv):
             m = importlib.import_module(v['module'])

--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -35,7 +35,7 @@ class Samples:
             storage: ArangoSampleStorage,
             user_lookup: KBaseUserLookup,  # make an interface? YAGNI
             metadata_validators: Dict[
-                str, List[Callable[[Dict[str, PrimitiveType]], Optional[str]]]] = None,
+                str, List[Callable[[str, Dict[str, PrimitiveType]], Optional[str]]]] = None,
             now: Callable[[], datetime.datetime] = lambda: datetime.datetime.now(
                 tz=datetime.timezone.utc),
             uuid_gen: Callable[[], UUID] = lambda: _uuid.uuid4()):
@@ -106,7 +106,7 @@ class Samples:
                     raise _MetadataValidationError(
                         f'No validator available for metadata key {k} for node at index {i}')
                 for valfunc in self._metaval[k]:
-                    ret = valfunc(n.controlled_metadata[k])
+                    ret = valfunc(k, n.controlled_metadata[k])
                     if ret:
                         raise _MetadataValidationError(f'Node at index {i}, key {k}: ' + ret)
 

--- a/lib/SampleService/core/validators/builtin.py
+++ b/lib/SampleService/core/validators/builtin.py
@@ -37,7 +37,7 @@ def noop(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[str
     :returns: a callable that validates metadata maps.
     '''
     _check_unknown_keys(d, [])
-    return lambda _: None
+    return lambda key, val: None
 
 
 def string(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[str]]:
@@ -75,7 +75,7 @@ def string(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[s
     keys = _get_keys(d)
     if keys:
 
-        def strlen(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+        def strlen(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
             for k in keys:
                 if required and k not in d1:
                     return f'Required key {k} is missing'
@@ -85,7 +85,7 @@ def string(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[s
                 if v and maxlen and len(v) > maxlen:
                     return f'Metadata value at key {k} is longer than max length of {maxlen}'
     elif maxlen:
-        def strlen(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+        def strlen(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
             for k, v in d1.items():
                 if len(k) > maxlen:
                     return f'Metadata contains key longer than max length of {maxlen}'
@@ -125,13 +125,13 @@ def enum(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[str
     keys = _get_keys(d)
     if keys:
 
-        def enumval(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+        def enumval(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
             for k in keys:
                 if d1.get(k) not in allowed:
                     return f'Metadata value at key {k} is not in the allowed list of values'
     else:
 
-        def enumval(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+        def enumval(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
             for k, v in d1.items():
                 if v not in allowed:
                     return f'Metadata value at key {k} is not in the allowed list of values'
@@ -191,7 +191,7 @@ def units(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[st
     except _DefinitionSyntaxError as e:
         raise ValueError(f"unable to parse units '{u}': syntax error: {e.args[0]}")
 
-    def unitval(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+    def unitval(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
         unitstr = d1.get(k)
         if not unitstr:
             return f'metadata value key {k} is required'
@@ -244,7 +244,7 @@ def number(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[s
     range_ = _get_range(d)
 
     if keys:
-        def strlen(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+        def strlen(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
             for k in keys:
                 if required and k not in d1:
                     return f'Required key {k} is missing'
@@ -254,7 +254,7 @@ def number(d: Dict[str, Any]) -> Callable[[Dict[str, PrimitiveType]], Optional[s
                 if v is not None and v not in range_:
                     return f'Metadata value at key {k} is not within the range {range_}'
     else:
-        def strlen(d1: Dict[str, PrimitiveType]) -> Optional[str]:
+        def strlen(key: str, d1: Dict[str, PrimitiveType]) -> Optional[str]:
             for k, v in d1.items():
                 # duplicate of above, meh.
                 if v is not None and type(v) not in types:

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -47,10 +47,10 @@ def test_save_sample():
 def _save_sample_with_name(name):
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': [lambda x: exec('assert x["val"] == "foo"'),  # this is vile
-                        lambda x: exec('assert "val" in x')
+    metaval = {'key1': [lambda k, x: exec('assert x["val"] == "foo"'),  # this is vile
+                        lambda k, x: exec('assert k == "key1"')
                         ],
-               'key2': [lambda _: None]  # noop
+               'key2': [lambda _, __: None]  # noop
                }
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
@@ -139,7 +139,7 @@ def test_save_sample_fail_bad_args():
 def test_save_sample_fail_no_metadata_validator():
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': [lambda _: None], 'key2': [lambda _: None], 'key3': []}
+    metaval = {'key1': [lambda _, __: None], 'key2': [lambda _, __: None], 'key3': []}
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 
@@ -161,7 +161,8 @@ def test_save_sample_fail_no_metadata_validator():
 def test_save_sample_fail_metadata_validator_exception():
     storage = create_autospec(ArangoSampleStorage, spec_set=True, instance=True)
     lu = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
-    metaval = {'key1': [lambda _: None], 'key2': [lambda _: None, lambda _: "u suk lol"]}
+    metaval = {'key1': [lambda _, __: None],
+               'key2': [lambda _, __: None, lambda _, __: "u suk lol"]}
     s = Samples(storage, lu, metadata_validators=metaval, now=nw,
                 uuid_gen=lambda: UUID('1234567890abcdef1234567890abcdef'))
 

--- a/test/core/validators/builtin_test.py
+++ b/test/core/validators/builtin_test.py
@@ -8,7 +8,7 @@ def test_noop():
     # not much to test here.
     n = builtin.noop({})
 
-    assert n({}) is None
+    assert n('key', {}) is None
 
 
 def test_noop_fail_bad_input():
@@ -26,7 +26,7 @@ def _noop_fail_build(cfg, expected):
 
 def test_string_general():
     sl = builtin.string({'max-len': 2})
-    assert sl({
+    assert sl('key', {
         'fo': 'b',
         'e': 'fb',
         'a': True,
@@ -36,7 +36,7 @@ def test_string_general():
 
 def test_string_single_keys():
     sl = builtin.string({'keys': 'whee', 'required': False})
-    assert sl({
+    assert sl('key', {
         'fo': 'b',
         'e': 'fb',
         'whee': 'whooooooooooooo',
@@ -48,7 +48,7 @@ def test_string_single_keys():
 def test_string_multiple_keys_max_len():
     sl = builtin.string({'keys': ['whee', 'whoo', 'whoa'], 'max-len': 9})
     # missing whoo key
-    assert sl({
+    assert sl('key', {
         'fo': 'b',
         'e': 'fb',
         'whee': 'whoo',
@@ -60,7 +60,7 @@ def test_string_multiple_keys_max_len():
 
 def test_string_multiple_keys_required():
     sl = builtin.string({'keys': ['whee', 'whoo', 'whoa'], 'required': True})
-    assert sl({
+    assert sl('key', {
         'fo': 'b',
         'e': 'fb',
         'whee': None,  # test that none is allowed as a value, even w/ required
@@ -109,25 +109,25 @@ def test_string_validate_fail_bad_metadata_values():
 
 
 def _string_validate_fail(cfg, meta, expected):
-    assert builtin.string(cfg)(meta) == expected
+    assert builtin.string(cfg)('key', meta) == expected
 
 
 def test_enum():
     en = builtin.enum({'allowed-values': ['a', 1, 3.1, True]})
 
-    assert en({'z': 'a', 'w': 1, 'x': 3.1, 'y': True}) is None
+    assert en('key', {'z': 'a', 'w': 1, 'x': 3.1, 'y': True}) is None
 
 
 def test_enum_with_single_key():
     en = builtin.enum({'keys': '4', 'allowed-values': ['b', 2, 3.2, False]})
 
-    assert en({'4': 2}) is None
+    assert en('key', {'4': 2}) is None
 
 
 def test_enum_with_keys():
     en = builtin.enum({'keys': ['1', '2', '3', '4'], 'allowed-values': ['b', 2, 3.2, False]})
 
-    assert en({'1': 'b', '2': 2, '3': 3.2, '4': False}) is None
+    assert en('key', {'1': 'b', '2': 2, '3': 3.2, '4': False}) is None
 
 
 def test_enum_build_fail():
@@ -170,7 +170,7 @@ def _enum_build_fail(cfg, expected):
 
 
 def _enum_validate_fail(cfg, meta, expected):
-    assert builtin.enum(cfg)(meta) == expected
+    assert builtin.enum(cfg)('key', meta) == expected
 
 
 def test_units():
@@ -180,7 +180,7 @@ def test_units():
 
 
 def _units_good(cfg, meta):
-    assert builtin.units(cfg)(meta) is None
+    assert builtin.units(cfg)('key', meta) is None
 
 
 def test_units_build_fail():
@@ -227,7 +227,7 @@ def _units_build_fail(cfg, expected):
 
 
 def _units_validate_fail(cfg, meta, expected):
-    assert builtin.units(cfg)(meta) == expected
+    assert builtin.units(cfg)('key', meta) == expected
 
 
 def test_number():
@@ -290,7 +290,7 @@ def test_number_with_keys_and_ranges():
 
 
 def _number_success(cfg, params):
-    assert builtin.number(cfg)(params) is None
+    assert builtin.number(cfg)('key', params) is None
 
 
 def test_number_build_fail():
@@ -372,4 +372,4 @@ def _number_build_fail(cfg, expected):
 
 
 def _number_validate_fail(cfg, meta, expected):
-    assert builtin.number(cfg)(meta) == expected
+    assert builtin.number(cfg)('key', meta) == expected


### PR DESCRIPTION
Will be needed for the case where the validators do not exactly match a
key, e.g. prefixes.