### PR TITLE
Add option to skip admin check and return false

### DIFF
--- a/lib/SampleService/core/api_translation.py
+++ b/lib/SampleService/core/api_translation.py
@@ -247,7 +247,8 @@ def check_admin(
         perm: AdminPermission,
         method: str,
         log_fn: Callable[[str], None],
-        as_user: str = None) -> None:
+        as_user: str = None,
+        skip_check: bool = False) -> bool:
     '''
     Check whether a user has admin privileges.
     The request is logged.
@@ -259,8 +260,13 @@ def check_admin(
       messages.
     :param logger: a function that logs information when called with a string.
     :param as_user: if the admin is impersonating another user, the username of that user.
+    :param skip_check: Skip the administration permission check and return false.
+    :returns: true if the user has the required administration permission, false if skip_check
+        is true.
     :throws UnauthorizedError: if the user does not have the permission required.
     '''
+    if skip_check:
+        return False
     _not_falsy(method, 'method')
     _not_falsy(log_fn, 'log_fn')
     if _not_falsy(perm, 'perm') == AdminPermission.NONE:
@@ -276,3 +282,4 @@ def check_admin(
         raise _UnauthorizedError(err)
     log_fn(f'User {user} is running method {method} with administration permission {p.name}' +
            (f' as user {as_user}' if as_user else ''))
+    return True

--- a/test/core/api_arguments_test.py
+++ b/test/core/api_arguments_test.py
@@ -21,6 +21,7 @@ from core.test_utils import assert_exception_correct
 
 # TODO NOW rename to api_translation
 
+
 def test_get_id_from_object():
     assert get_id_from_object(None, False) is None
     assert get_id_from_object({}, False) is None
@@ -456,7 +457,7 @@ def _check_admin(perm, permreq, user, method, as_user, expected_log):
     assert logs == [expected_log]
 
 
-def _check_admin_skip():
+def test_check_admin_skip():
     ul = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
     logs = []
 

--- a/test/core/api_arguments_test.py
+++ b/test/core/api_arguments_test.py
@@ -19,6 +19,7 @@ from SampleService.core.user_lookup import KBaseUserLookup
 
 from core.test_utils import assert_exception_correct
 
+# TODO NOW rename to api_translation
 
 def test_get_id_from_object():
     assert get_id_from_object(None, False) is None
@@ -448,10 +449,24 @@ def _check_admin(perm, permreq, user, method, as_user, expected_log):
 
     ul.is_admin.return_value = (perm, user)
 
-    check_admin(ul, 'thisisatoken', permreq, method, lambda x: logs.append(x), as_user)
+    assert check_admin(
+        ul, 'thisisatoken', permreq, method, lambda x: logs.append(x), as_user) is True
 
     assert ul.is_admin.call_args_list == [(('thisisatoken',), {})]
     assert logs == [expected_log]
+
+
+def _check_admin_skip():
+    ul = create_autospec(KBaseUserLookup, spec_set=True, instance=True)
+    logs = []
+
+    ul.is_admin.return_value = (AdminPermission.FULL, 'u')
+
+    assert check_admin(ul, 'thisisatoken', AdminPermission.FULL, 'm', lambda x: logs.append(x),
+                       skip_check=True) is False
+
+    assert ul.is_admin.call_args_list == []
+    assert logs == []
 
 
 def test_check_admin_fail_bad_args():


### PR DESCRIPTION
Skipping the check implies the user is not acting as an admin. Reduces code
in the Impl class.