### PR TITLE
Add test for data linking self-correction code, turn on consistency checker

### DIFF
--- a/lib/SampleService/core/config.py
+++ b/lib/SampleService/core/config.py
@@ -96,6 +96,7 @@ def build_samples(config: Dict[str, str]) -> Tuple[Samples, KBaseUserLookup]:
         'fake_data',  # TODO DATALINK get from config
         col_schema,
     )
+    storage.start_consistency_checker()
     user_lookup = KBaseUserLookup(auth_root_url, auth_token, full_roles, read_roles)
     return Samples(storage, user_lookup, metaval), user_lookup
 


### PR DESCRIPTION
Add a test that ensures the self correction code is run when a problem is
detected in the version doc when linking data.

Also turn on the consistency checker, can't believe I missed that.