### PR TITLE
adding 'verbose' argument to get_key_metadata_static_metadata

### DIFF
--- a/SampleService.spec
+++ b/SampleService.spec
@@ -289,10 +289,14 @@ module SampleService {
             1 to interrogate prefix metadata keys, but require an exact match to the prefix key.
             2 to interrogate prefix metadata keys, but any keys which are a prefix of the
                 provided keys will be included in the results.
+        verbose - optional (default = False)
+            False - raise first key error as it comes up
+            True - raise all key errors together
      */
     typedef structure {
         list<metadata_key> keys;
         int prefix;
+        boolean verbose;
     } GetMetadataKeyStaticMetadataParams;
 
     /* get_metadata_key_static_metadata results.

--- a/lib/SampleService/SampleServiceImpl.py
+++ b/lib/SampleService/SampleServiceImpl.py
@@ -586,8 +586,8 @@ Note that usage of the administration flags will be logged by the service.
         # ctx is the context object
         # return variables are: results
         #BEGIN get_metadata_key_static_metadata
-        keys, prefix = _get_static_key_metadata_params(params)
-        results = {'static_metadata': self._samples.get_key_static_metadata(keys, prefix=prefix)}
+        keys, prefix, verbose = _get_static_key_metadata_params(params)
+        results = {'static_metadata': self._samples.get_key_static_metadata(keys, prefix=prefix, verbose=verbose)}
         #END get_metadata_key_static_metadata
 
         # At some point might do deeper type checking...

--- a/lib/SampleService/core/api_translation.py
+++ b/lib/SampleService/core/api_translation.py
@@ -487,7 +487,7 @@ def check_admin(
     return True
 
 
-def get_static_key_metadata_params(params: Dict[str, Any]) -> Tuple[List[str], Optional[bool]]:
+def get_static_key_metadata_params(params: Dict[str, Any]) -> Tuple[List[str], Optional[bool], bool]:
     '''
     Given a dict, extract the parameters to interrogate metadata key static metadata.
 
@@ -516,7 +516,8 @@ def get_static_key_metadata_params(params: Dict[str, Any]) -> Tuple[List[str], O
         pre = True
     else:
         raise _IllegalParameterError(f'Unexpected value for prefix: {prefix}')
-    return _cast(List[str], keys), pre
+    v = bool(params.get('verbose', False))
+    return _cast(List[str], keys), pre, v
 
 
 def create_data_link_params(params: Dict[str, Any]) -> Tuple[DataUnitID, SampleNodeAddress, bool]:

--- a/lib/SampleService/core/samples.py
+++ b/lib/SampleService/core/samples.py
@@ -312,7 +312,8 @@ class Samples:
     def get_key_static_metadata(
             self,
             keys: List[str],
-            prefix: Union[bool, None] = False
+            prefix: Union[bool, None] = False,
+            verbose: bool = False
             ) -> Dict[str, Dict[str, PrimitiveType]]:
         '''
         Get any static metadata associated with the provided list of keys.
@@ -325,9 +326,9 @@ class Samples:
         if keys is None:
             raise ValueError('keys cannot be None')
         if prefix is False:
-            return self._metaval.key_metadata(keys)
+            return self._metaval.key_metadata(keys, verbose=verbose)
         else:
-            return self._metaval.prefix_key_metadata(keys, exact_match=not bool(prefix))
+            return self._metaval.prefix_key_metadata(keys, exact_match=not bool(prefix), verbose=verbose)
 
     def create_data_link(
             self,

--- a/test/SampleService_test.py
+++ b/test/SampleService_test.py
@@ -2011,6 +2011,8 @@ def test_get_metadata_key_static_metadata(sample_port):
         sample_port, {'keys': ['pre'], 'prefix': 1}, {'pre': {'1': '2'}})
     _get_metadata_key_static_metadata(
         sample_port, {'keys': ['premature'], 'prefix': 2}, {'pre': {'1': '2'}})
+    _get_metadata_key_static_metadata(
+        sample_port, {'keys': ['foo'], 'prefix': 0, 'verbose': 1}, {'foo': {'a': 'b', 'c': 'd'}})
 
 
 def _get_metadata_key_static_metadata(sample_port, params, expected):
@@ -2047,6 +2049,21 @@ def test_get_metadata_key_static_metadata_fail_bad_args(sample_port):
         {'keys': ['somekey'], 'prefix': 2},
         'Sample service error code 30001 Illegal input parameter: No prefix metadata keys ' +
         'matching key somekey')
+    _get_metadata_key_static_metadata_fail(
+        sample_port,
+        {'keys': ['yabadoo', 'tumtum'], 'prefix': 0, 'verbose': 1},
+        'Sample service error code 30001 Illegal input parameter: ' +
+        'No such metadata keys: yabadoo, tumtum')
+    _get_metadata_key_static_metadata_fail(
+        sample_port,
+        {'keys': ['yabadoo', 'tumtum'], 'prefix': 1, 'verbose': 1},
+        'Sample service error code 30001 Illegal input parameter: ' +
+        'No such prefix metadata keys: yabadoo, tumtum')
+    _get_metadata_key_static_metadata_fail(
+        sample_port,
+        {'keys': ['yabadoo', 'tumtum'], 'prefix': 2, 'verbose': 1},
+        'Sample service error code 30001 Illegal input parameter: ' +
+        'No prefix metadata keys matching keys: yabadoo, tumtum')
 
 
 def _get_metadata_key_static_metadata_fail(sample_port, params, error):

--- a/test/core/api_translation_test.py
+++ b/test/core/api_translation_test.py
@@ -831,14 +831,14 @@ def _check_admin_fail(ul, token, perm, method, logfn, as_user, expected):
 
 
 def test_get_static_key_metadata_params():
-    assert get_static_key_metadata_params({'keys': []}) == ([], False)
-    assert get_static_key_metadata_params({'keys': ['foo'], 'prefix': None}) == (['foo'], False)
+    assert get_static_key_metadata_params({'keys': []}) == ([], False, False)
+    assert get_static_key_metadata_params({'keys': ['foo'], 'prefix': None}) == (['foo'], False, False)
     assert get_static_key_metadata_params({'keys': ['bar', 'foo'], 'prefix': 0}) == (
-        ['bar', 'foo'], False)
-    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': False}) == (['bar'], False)
-    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': 1}) == (['bar'], None)
-    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': 2}) == (['bar'], True)
-
+        ['bar', 'foo'], False, False)
+    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': False}) == (['bar'], False, False)
+    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': 1}) == (['bar'], None, False)
+    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': 2}) == (['bar'], True, False)
+    assert get_static_key_metadata_params({'keys': ['bar'], 'prefix': 2, 'verbose': 1}) == (['bar'], True, True)
 
 def test_get_static_key_metadata_params_fail_bad_args():
     _get_static_key_metadata_params_fail(None, ValueError('params cannot be None'))

--- a/test/core/samples_test.py
+++ b/test/core/samples_test.py
@@ -1212,11 +1212,11 @@ def test_get_key_metadata():
 
     assert s.get_key_static_metadata(['a', 'b']) == {'a': {'c': 'd'}, 'b': {'e': 3}}
 
-    meta.key_metadata.assert_called_once_with(['a', 'b'])
+    meta.key_metadata.assert_called_once_with(['a', 'b'], verbose=False)
 
     assert s.get_key_static_metadata(['a', 'b'], prefix=False) == {'a': {'c': 'e'}, 'b': {'e': 4}}
 
-    meta.key_metadata.assert_called_with(['a', 'b'])
+    meta.key_metadata.assert_called_with(['a', 'b'], verbose=False)
 
     assert meta.key_metadata.call_count == 2
 
@@ -1237,12 +1237,12 @@ def test_get_prefix_key_metadata():
     assert s.get_key_static_metadata(['a', 'b'], prefix=None) == {
         'a': {'c': 'd'}, 'b': {'e': 3}}
 
-    meta.prefix_key_metadata.assert_called_once_with(['a', 'b'], exact_match=True)
+    meta.prefix_key_metadata.assert_called_once_with(['a', 'b'], exact_match=True, verbose=False)
 
     assert s.get_key_static_metadata(['a', 'b'], prefix=True) == {
         'a': {'c': 'f'}, 'b': {'e': 5}}
 
-    meta.prefix_key_metadata.assert_called_with(['a', 'b'], exact_match=False)
+    meta.prefix_key_metadata.assert_called_with(['a', 'b'], exact_match=False, verbose=False)
 
     assert meta.prefix_key_metadata.call_count == 2
 


### PR DESCRIPTION
Allows for checking all metadata fields provided first before resulting in error.